### PR TITLE
Fix two GBA cheat typos

### DIFF
--- a/cht/Nintendo - Game Boy Advance/Pokemon - Feuerrote Edition (G).cht
+++ b/cht/Nintendo - Game Boy Advance/Pokemon - Feuerrote Edition (G).cht
@@ -19,7 +19,7 @@ cheat3_enable = false
 cheat4_desc = "Infinite Money"
 cheat4_code = "29C78059+96542194"
 cheat4_enable = false
-c
+
 cheat5_desc = "Low Game Time"
 cheat5_code = "FD0B58A2+8499AAE6+68D10800+E90843E7"
 cheat5_enable = false

--- a/cht/Nintendo - Game Boy Advance/Summon Night - Swordcraft Story (USA) (Code Breaker).cht
+++ b/cht/Nintendo - Game Boy Advance/Summon Night - Swordcraft Story (USA) (Code Breaker).cht
@@ -1,4 +1,4 @@
-cheats = 174
+cheats = 175
 
 cheat0_desc = "Enable Code"
 cheat0_code = "0000C72E+000A+10069BC4+0007"


### PR DESCRIPTION
These were found when investigating https://github.com/jer-irl/update_ezflash_cheats/issues/1